### PR TITLE
Add Google Map to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,6 +293,17 @@
         .footer .footer-links { margin-bottom: 20px; }
         .footer .design-credit { font-style: italic; margin-bottom: 20px; }
 
+        /* Map Section */
+        .map-section {
+            width: 100%;
+            height: 400px;
+        }
+        .map-section iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+
         /* Responsive */
         @media (max-width: 1024px) {
             .detail-gallery-grid, .wood-types-grid { grid-template-columns: repeat(2, 1fr); }
@@ -452,6 +463,10 @@
         <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
         <p><a href="tel:+31628566553">0628566553</a></p>
     </footer>
+
+    <section class="map-section">
+        <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    </section>
 
     <div id="delayed-lightbox">
         <button id="lightbox-close-btn" class="lightbox-close">&times;</button>


### PR DESCRIPTION
## Summary
- style map section and embed Google Map
- add map section under the footer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d64b614ec832bac5ca5db44ddeaae