### PR TITLE
Use map as footer background

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,20 +288,45 @@
         }
 
         /* Footer */
-        .footer { text-align: center; padding: 40px 20px; background-color: #2F4858; color: #EAE7E1; font-size: 0.9rem; line-height: 1.8; }
+        .footer {
+            position: relative;
+            text-align: center;
+            padding: 40px 20px;
+            color: #EAE7E1;
+            font-size: 0.9rem;
+            line-height: 1.8;
+            overflow: hidden;
+            min-height: 300px;
+        }
         .footer a { color: #EAE7E1; text-decoration: underline; margin: 0 10px; }
         .footer .footer-links { margin-bottom: 20px; }
         .footer .design-credit { font-style: italic; margin-bottom: 20px; }
-
-        /* Map Section */
-        .map-section {
+        .footer-map {
+            position: absolute;
+            top: 0;
+            left: 0;
             width: 100%;
-            height: 400px;
+            height: 100%;
+            z-index: 0;
         }
-        .map-section iframe {
+        .footer-map iframe {
             width: 100%;
             height: 100%;
             border: 0;
+        }
+        .footer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            z-index: 1;
+        }
+        .footer-content {
+            position: relative;
+            z-index: 2;
         }
 
         /* Responsive */
@@ -447,7 +472,11 @@
     </section>
 
     <footer class="footer">
-        <div class="footer-links">
+        <div class="footer-map">
+            <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+        <div class="footer-content">
+            <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a>
             <a href="instructies.html" lang="en">Hanging Instructions</a>
             <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
@@ -462,11 +491,8 @@
         <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
         <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
         <p><a href="tel:+31628566553">0628566553</a></p>
+        </div>
     </footer>
-
-    <section class="map-section">
-        <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-    </section>
 
     <div id="delayed-lightbox">
         <button id="lightbox-close-btn" class="lightbox-close">&times;</button>

--- a/instructies.html
+++ b/instructies.html
@@ -14,9 +14,45 @@
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
-        .footer { text-align: center; padding: 40px 20px; background-color: #2F4858; color: #EAE7E1; font-size: 0.9rem; line-height: 1.8; }
+        .footer {
+            position: relative;
+            text-align: center;
+            padding: 40px 20px;
+            color: #EAE7E1;
+            font-size: 0.9rem;
+            line-height: 1.8;
+            overflow: hidden;
+            min-height: 300px;
+        }
         .footer a { color: #EAE7E1; text-decoration: underline; margin: 0 10px; }
         .footer .footer-links { margin-bottom: 20px; }
+        .footer-map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+        }
+        .footer-map iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .footer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            z-index: 1;
+        }
+        .footer-content {
+            position: relative;
+            z-index: 2;
+        }
         .video-placeholder { width: 100%; height: 0; padding-bottom: 56.25%; background-color: #ccc; position: relative; border-radius: 8px; }
         .video-placeholder::after { content: '►'; font-size: 5rem; color: #fff; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }
         .steps { margin-top: 40px; }
@@ -68,15 +104,20 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+        <div class="footer-map">
+            <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
         </div>
-        <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
-        <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
-        <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        <div class="footer-content">
+            <div class="footer-links">
+                <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
+                <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
+                <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
+                <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+            </div>
+            <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
+            <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
+            <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        </div>
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/over-ons.html
+++ b/over-ons.html
@@ -14,9 +14,45 @@
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
-        .footer { text-align: center; padding: 40px 20px; background-color: #2F4858; color: #EAE7E1; font-size: 0.9rem; line-height: 1.8; }
+        .footer {
+            position: relative;
+            text-align: center;
+            padding: 40px 20px;
+            color: #EAE7E1;
+            font-size: 0.9rem;
+            line-height: 1.8;
+            overflow: hidden;
+            min-height: 300px;
+        }
         .footer a { color: #EAE7E1; text-decoration: underline; margin: 0 10px; }
         .footer .footer-links { margin-bottom: 20px; }
+        .footer-map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+        }
+        .footer-map iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .footer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            z-index: 1;
+        }
+        .footer-content {
+            position: relative;
+            z-index: 2;
+        }
     </style>
 </head>
 <body class="lang-nl">
@@ -36,15 +72,20 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+        <div class="footer-map">
+            <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
         </div>
-        <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
-        <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
-        <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        <div class="footer-content">
+            <div class="footer-links">
+                <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
+                <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
+                <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
+                <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+            </div>
+            <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
+            <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
+            <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        </div>
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -13,9 +13,45 @@
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
-        .footer { text-align: center; padding: 40px 20px; background-color: #2F4858; color: #EAE7E1; font-size: 0.9rem; line-height: 1.8; }
+        .footer {
+            position: relative;
+            text-align: center;
+            padding: 40px 20px;
+            color: #EAE7E1;
+            font-size: 0.9rem;
+            line-height: 1.8;
+            overflow: hidden;
+            min-height: 300px;
+        }
         .footer a { color: #EAE7E1; text-decoration: underline; margin: 0 10px; }
         .footer .footer-links { margin-bottom: 20px; }
+        .footer-map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+        }
+        .footer-map iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .footer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            z-index: 1;
+        }
+        .footer-content {
+            position: relative;
+            z-index: 2;
+        }
         .spec-table { width: 100%; border-collapse: collapse; margin-top: 2rem; }
         .spec-table th, .spec-table td { border: 1px solid #ddd; padding: 12px; text-align: left; }
         .spec-table th { background-color: #EAE7E1; }
@@ -78,15 +114,20 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+        <div class="footer-map">
+            <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
         </div>
-        <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
-        <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
-        <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        <div class="footer-content">
+            <div class="footer-links">
+                <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
+                <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
+                <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
+                <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+            </div>
+            <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
+            <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
+            <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        </div>
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -15,9 +15,45 @@
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
-        .footer { text-align: center; padding: 40px 20px; background-color: #2F4858; color: #EAE7E1; font-size: 0.9rem; line-height: 1.8; }
+        .footer {
+            position: relative;
+            text-align: center;
+            padding: 40px 20px;
+            color: #EAE7E1;
+            font-size: 0.9rem;
+            line-height: 1.8;
+            overflow: hidden;
+            min-height: 300px;
+        }
         .footer a { color: #EAE7E1; text-decoration: underline; margin: 0 10px; }
         .footer .footer-links { margin-bottom: 20px; }
+        .footer-map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+        }
+        .footer-map iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .footer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            z-index: 1;
+        }
+        .footer-content {
+            position: relative;
+            z-index: 2;
+        }
         .disclaimer { background-color: #EAE7E1; border-left: 4px solid #2F4858; padding: 15px; margin-bottom: 20px; font-style: italic;}
     </style>
 </head>
@@ -83,15 +119,20 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+        <div class="footer-map">
+            <iframe src="https://maps.google.com/maps?q=Poeldonkweg%205%2C%205216%20JX%20's-Hertogenbosch&output=embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
         </div>
-        <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
-        <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
-        <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        <div class="footer-content">
+            <div class="footer-links">
+                <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
+                <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
+                <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
+                <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
+            </div>
+            <p class="design-credit" lang="nl">Ontworpen en gemaakt door Olle.</p><p class="design-credit" lang="en">Designed and made by Olle.</p>
+            <p>Olle</p><p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>
+            <p><a href="mailto:olle@olle.link">olle@olle.link</a></p><p><a href="tel:+31628566553">0628566553</a></p>
+        </div>
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- use Google Maps as the footer background
- add dark overlay so footer text stays readable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d6699deb8832b9352549cc0623fb9