### PR TITLE
Add top navigation and clean footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,20 @@
             justify-content: space-between;
             align-items: center;
         }
+        .main-menu {
+            flex: 1;
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+        }
+        .main-menu a {
+            color: #fff;
+            text-decoration: none;
+        }
+        .main-menu a:hover {
+            text-decoration: underline;
+        }
         .header-logo { width: 150px; height: auto; }
 
         /* Language Switcher */
@@ -332,6 +346,16 @@
 
     <header class="header">
         <a href="index.html"><img src="92951ba3-4df4-455e-8134-156c8b7d57d3 (1).png" alt="Mori Logo" class="header-logo"></a>
+        <nav class="main-menu">
+            <a href="instructies.html" lang="nl">Ophanginstructies</a>
+            <a href="instructies.html" lang="en">Hanging Instructions</a>
+            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
+            <a href="voorwaarden.html" lang="en">Terms &amp; Conditions</a>
+            <a href="over-ons.html" lang="nl">Over Ons</a>
+            <a href="over-ons.html" lang="en">About Us</a>
+            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
+            <a href="tech-specs.html" lang="en">Technical Specs</a>
+        </nav>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
             <img src="https://flagcdn.com/gb.svg" alt="English" id="lang-en-btn">
@@ -446,16 +470,6 @@
     </section>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a>
-            <a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
-            <a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a>
-            <a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
-            <a href="tech-specs.html" lang="en">Technical Specs</a>
-        </div>
         <div class="footer-contact">
             <p>Mori by Olle</p>
             <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>

--- a/instructies.html
+++ b/instructies.html
@@ -12,6 +12,18 @@
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; }
         .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
         .header-logo { width: 150px; height: auto; }
+        .main-menu {
+            flex: 1;
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+        }
+        .main-menu a {
+            color: #2F4858;
+            text-decoration: none;
+        }
+        .main-menu a:hover { text-decoration: underline; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
@@ -38,6 +50,16 @@
 <body class="lang-nl">
     <header class="header">
         <a href="index.html"><img src="92951ba3-4df4-455e-8134-156c8b7d57d3 (1).png" alt="Mori Logo" class="header-logo"></a>
+        <nav class="main-menu">
+            <a href="instructies.html" lang="nl">Ophanginstructies</a>
+            <a href="instructies.html" lang="en">Hanging Instructions</a>
+            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
+            <a href="voorwaarden.html" lang="en">Terms &amp; Conditions</a>
+            <a href="over-ons.html" lang="nl">Over Ons</a>
+            <a href="over-ons.html" lang="en">About Us</a>
+            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
+            <a href="tech-specs.html" lang="en">Technical Specs</a>
+        </nav>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
             <img src="https://flagcdn.com/gb.svg" alt="English" id="lang-en-btn">
@@ -79,12 +101,6 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
-        </div>
         <div class="footer-contact">
             <p>Mori by Olle</p>
             <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>

--- a/over-ons.html
+++ b/over-ons.html
@@ -12,6 +12,18 @@
         .story-text { line-height: 1.8; font-size: 1.2rem; }
         .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
         .header-logo { width: 150px; height: auto; }
+        .main-menu {
+            flex: 1;
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+        }
+        .main-menu a {
+            color: #2F4858;
+            text-decoration: none;
+        }
+        .main-menu a:hover { text-decoration: underline; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
@@ -40,6 +52,16 @@
 <body class="lang-nl">
     <header class="header">
         <a href="index.html"><img src="92951ba3-4df4-455e-8134-156c8b7d57d3 (1).png" alt="Mori Logo" class="header-logo"></a>
+        <nav class="main-menu">
+            <a href="instructies.html" lang="nl">Ophanginstructies</a>
+            <a href="instructies.html" lang="en">Hanging Instructions</a>
+            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
+            <a href="voorwaarden.html" lang="en">Terms &amp; Conditions</a>
+            <a href="over-ons.html" lang="nl">Over Ons</a>
+            <a href="over-ons.html" lang="en">About Us</a>
+            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
+            <a href="tech-specs.html" lang="en">Technical Specs</a>
+        </nav>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
             <img src="https://flagcdn.com/gb.svg" alt="English" id="lang-en-btn">
@@ -59,12 +81,6 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
-        </div>
         <div class="footer-contact">
             <p>Mori by Olle</p>
             <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -11,6 +11,18 @@
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; }
         .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
         .header-logo { width: 150px; height: auto; }
+        .main-menu {
+            flex: 1;
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+        }
+        .main-menu a {
+            color: #2F4858;
+            text-decoration: none;
+        }
+        .main-menu a:hover { text-decoration: underline; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
@@ -35,6 +47,16 @@
 <body class="lang-nl">
     <header class="header">
         <a href="index.html"><img src="92951ba3-4df4-455e-8134-156c8b7d57d3 (1).png" alt="Mori Logo" class="header-logo"></a>
+        <nav class="main-menu">
+            <a href="instructies.html" lang="nl">Ophanginstructies</a>
+            <a href="instructies.html" lang="en">Hanging Instructions</a>
+            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
+            <a href="voorwaarden.html" lang="en">Terms &amp; Conditions</a>
+            <a href="over-ons.html" lang="nl">Over Ons</a>
+            <a href="over-ons.html" lang="en">About Us</a>
+            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
+            <a href="tech-specs.html" lang="en">Technical Specs</a>
+        </nav>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
             <img src="https://flagcdn.com/gb.svg" alt="English" id="lang-en-btn">
@@ -89,12 +111,6 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
-        </div>
         <div class="footer-contact">
             <p>Mori by Olle</p>
             <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -13,6 +13,18 @@
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; line-height: 1.6; }
         .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
         .header-logo { width: 150px; height: auto; }
+        .main-menu {
+            flex: 1;
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+        }
+        .main-menu a {
+            color: #2F4858;
+            text-decoration: none;
+        }
+        .main-menu a:hover { text-decoration: underline; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
@@ -35,6 +47,16 @@
 <body class="lang-nl">
     <header class="header">
         <a href="index.html"><img src="92951ba3-4df4-455e-8134-156c8b7d57d3 (1).png" alt="Mori Logo" class="header-logo"></a>
+        <nav class="main-menu">
+            <a href="instructies.html" lang="nl">Ophanginstructies</a>
+            <a href="instructies.html" lang="en">Hanging Instructions</a>
+            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a>
+            <a href="voorwaarden.html" lang="en">Terms &amp; Conditions</a>
+            <a href="over-ons.html" lang="nl">Over Ons</a>
+            <a href="over-ons.html" lang="en">About Us</a>
+            <a href="tech-specs.html" lang="nl">Technische Gegevens</a>
+            <a href="tech-specs.html" lang="en">Technical Specs</a>
+        </nav>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
             <img src="https://flagcdn.com/gb.svg" alt="English" id="lang-en-btn">
@@ -94,12 +116,6 @@
     </main>
 
     <footer class="footer">
-        <div class="footer-links">
-            <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
-            <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
-            <a href="over-ons.html" lang="nl">Over Ons</a><a href="over-ons.html" lang="en">About Us</a>
-            <a href="tech-specs.html" lang="nl">Technische Gegevens</a><a href="tech-specs.html" lang="en">Technical Specs</a>
-        </div>
         <div class="footer-contact">
             <p>Mori by Olle</p>
             <p>Poeldonkweg 5, 5216 JX ’s-Hertogenbosch</p>


### PR DESCRIPTION
## Summary
- center a new navigation menu in the header on every page
- move footer links into this menu and remove them from the footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4a000228832ba1da83913555e73e