### PR TITLE
Align footer contents with form section

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,18 +289,22 @@
 
         /* Footer */
         .footer {
+            background-color: #2F4858;
+            color: #EAE7E1;
+            padding: 40px 20px;
+        }
+        .footer-container {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            padding: 40px 20px;
-            background-color: #2F4858;
-            color: #EAE7E1;
+            max-width: 1200px;
+            margin: 0 auto;
             font-size: 0.9rem;
             line-height: 1.8;
-            text-align: center;
+            text-align: left;
         }
         .footer a { color: #EAE7E1; text-decoration: underline; }
-        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: center; }
+        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
 
         /* Responsive */
@@ -446,6 +450,7 @@
     </section>
 
     <footer class="footer">
+        <div class="footer-container">
         <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a>
             <a href="instructies.html" lang="en">Hanging Instructions</a>
@@ -462,6 +467,7 @@
             <p><a href="https://olle.link">Olle.link</a></p>
             <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
             <p><a href="tel:+31628566553">0031628566553</a></p>
+        </div>
         </div>
     </footer>
 

--- a/instructies.html
+++ b/instructies.html
@@ -15,18 +15,22 @@
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
+            background-color: #2F4858;
+            color: #EAE7E1;
+            padding: 40px 20px;
+        }
+        .footer-container {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            padding: 40px 20px;
-            background-color: #2F4858;
-            color: #EAE7E1;
+            max-width: 1200px;
+            margin: 0 auto;
             font-size: 0.9rem;
             line-height: 1.8;
-            text-align: center;
+            text-align: left;
         }
         .footer a { color: #EAE7E1; text-decoration: underline; }
-        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: center; }
+        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
         .video-placeholder { width: 100%; height: 0; padding-bottom: 56.25%; background-color: #ccc; position: relative; border-radius: 8px; }
         .video-placeholder::after { content: '►'; font-size: 5rem; color: #fff; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }
@@ -79,6 +83,7 @@
     </main>
 
     <footer class="footer">
+        <div class="footer-container">
         <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
             <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
@@ -91,6 +96,7 @@
             <p><a href="https://olle.link">Olle.link</a></p>
             <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
             <p><a href="tel:+31628566553">0031628566553</a></p>
+        </div>
         </div>
     </footer>
     <script>

--- a/over-ons.html
+++ b/over-ons.html
@@ -15,18 +15,22 @@
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
+            background-color: #2F4858;
+            color: #EAE7E1;
+            padding: 40px 20px;
+        }
+        .footer-container {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            padding: 40px 20px;
-            background-color: #2F4858;
-            color: #EAE7E1;
+            max-width: 1200px;
+            margin: 0 auto;
             font-size: 0.9rem;
             line-height: 1.8;
-            text-align: center;
+            text-align: left;
         }
         .footer a { color: #EAE7E1; text-decoration: underline; }
-        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: center; }
+        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
         .map-container {
             width: 100vw;
@@ -59,6 +63,7 @@
     </main>
 
     <footer class="footer">
+        <div class="footer-container">
         <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
             <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
@@ -71,6 +76,7 @@
             <p><a href="https://olle.link">Olle.link</a></p>
             <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
             <p><a href="tel:+31628566553">0031628566553</a></p>
+        </div>
         </div>
     </footer>
     <script>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -14,18 +14,22 @@
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
+            background-color: #2F4858;
+            color: #EAE7E1;
+            padding: 40px 20px;
+        }
+        .footer-container {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            padding: 40px 20px;
-            background-color: #2F4858;
-            color: #EAE7E1;
+            max-width: 1200px;
+            margin: 0 auto;
             font-size: 0.9rem;
             line-height: 1.8;
-            text-align: center;
+            text-align: left;
         }
         .footer a { color: #EAE7E1; text-decoration: underline; }
-        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: center; }
+        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
         .spec-table { width: 100%; border-collapse: collapse; margin-top: 2rem; }
         .spec-table th, .spec-table td { border: 1px solid #ddd; padding: 12px; text-align: left; }
@@ -89,6 +93,7 @@
     </main>
 
     <footer class="footer">
+        <div class="footer-container">
         <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
             <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
@@ -101,6 +106,7 @@
             <p><a href="https://olle.link">Olle.link</a></p>
             <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
             <p><a href="tel:+31628566553">0031628566553</a></p>
+        </div>
         </div>
     </footer>
     <script>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -16,18 +16,22 @@
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
         .footer {
+            background-color: #2F4858;
+            color: #EAE7E1;
+            padding: 40px 20px;
+        }
+        .footer-container {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            padding: 40px 20px;
-            background-color: #2F4858;
-            color: #EAE7E1;
+            max-width: 1200px;
+            margin: 0 auto;
             font-size: 0.9rem;
             line-height: 1.8;
-            text-align: center;
+            text-align: left;
         }
         .footer a { color: #EAE7E1; text-decoration: underline; }
-        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: center; }
+        .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
         .disclaimer { background-color: #EAE7E1; border-left: 4px solid #2F4858; padding: 15px; margin-bottom: 20px; font-style: italic;}
     </style>
@@ -94,6 +98,7 @@
     </main>
 
     <footer class="footer">
+        <div class="footer-container">
         <div class="footer-links">
             <a href="instructies.html" lang="nl">Ophanginstructies</a><a href="instructies.html" lang="en">Hanging Instructions</a>
             <a href="voorwaarden.html" lang="nl">Algemene Voorwaarden</a><a href="voorwaarden.html" lang="en">Terms & Conditions</a>
@@ -106,6 +111,7 @@
             <p><a href="https://olle.link">Olle.link</a></p>
             <p><a href="mailto:olle@olle.link">olle@olle.link</a></p>
             <p><a href="tel:+31628566553">0031628566553</a></p>
+        </div>
         </div>
     </footer>
     <script>


### PR DESCRIPTION
## Summary
- left-align footer text and links
- wrap footer contents with a centered container so the links match the registration section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e526a090c832bb023de8cad439ed7