### PR TITLE
Implement sticky header with scroll behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mori - Light That Lives</title>
     <style>
+        :root {
+            --accent-color: #2F4858;
+        }
+
         /* General Styles */
         body, html {
             margin: 0;
@@ -47,10 +51,9 @@
         }
 
         /* Header */
-        .header {
-            position: absolute;
+        .site-header {
+            position: sticky;
             top: 0;
-            left: 0;
             width: 100%;
             padding: 20px 40px;
             box-sizing: border-box;
@@ -58,6 +61,13 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            border-bottom: 4px solid var(--accent-color);
+            transition: all 0.3s ease;
+        }
+        .site-header.scrolled {
+            padding: 10px 40px;
+            background: #fff;
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
         }
         .header-logo { width: 150px; height: auto; }
 
@@ -319,7 +329,7 @@
             .section-full-width { padding: 40px 0; }
             .detail-gallery-title {padding: 0 15px;}
             .lamp-section { flex-direction: column; padding: 40px 15px; }
-            .header { padding: 20px; }
+            .site-header { padding: 20px; }
             .header-logo { width: 120px; }
             .lang-switcher img { width: 25px; }
         }
@@ -336,7 +346,7 @@
 </head>
 <body class="lang-nl">
 
-    <header class="header">
+    <header class="site-header">
         <a href="index.html"><img src="logo-light.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
@@ -497,6 +507,11 @@
             }
             nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
+
+            const header = document.querySelector('.site-header');
+            document.addEventListener('scroll', () => {
+                header.classList.toggle('scrolled', window.pageYOffset > 0);
+            });
 
             // Lightbox
             const lightbox = document.getElementById('delayed-lightbox');

--- a/instructies.html
+++ b/instructies.html
@@ -5,12 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ophanginstructies - Mori</title>
     <style>
+        :root {
+            --accent-color: #2F4858;
+        }
         body, html { margin: 0; padding: 0; font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #F8F5F2; color: #333; scroll-behavior: smooth; }
         .lang-nl [lang="en"] { display: none; } .lang-en [lang="nl"] { display: none; }
         h1, h2, h3 { font-family: 'Times New Roman', serif; font-weight: normal; }
         h1 { font-size: 2.5rem; text-align: center; margin-bottom: 2rem; color: #2F4858;}
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; }
-        .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
+        .site-header {
+            position: sticky;
+            top: 0;
+            width: 100%;
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 4px solid var(--accent-color);
+            transition: all 0.3s ease;
+        }
+        .site-header.scrolled {
+            padding: 10px 40px;
+            background: #fff;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
@@ -42,7 +60,7 @@
     </style>
 </head>
 <body class="lang-nl">
-    <header class="header">
+    <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
@@ -114,6 +132,11 @@
             }
             nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
+
+            const header = document.querySelector('.site-header');
+            document.addEventListener('scroll', () => {
+                header.classList.toggle('scrolled', window.pageYOffset > 0);
+            });
         });
     </script>
 </body>

--- a/over-ons.html
+++ b/over-ons.html
@@ -5,12 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Over Ons - Mori</title>
     <style>
+        :root {
+            --accent-color: #2F4858;
+        }
         body, html { margin: 0; padding: 0; font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #F8F5F2; color: #333; scroll-behavior: smooth; }
         .lang-nl [lang="en"] { display: none; } .lang-en [lang="nl"] { display: none; }
         h1 { font-family: 'Times New Roman', serif; font-weight: normal; font-size: 2.5rem; text-align: center; margin-bottom: 2rem; color: #2F4858;}
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; text-align: center; }
         .story-text { line-height: 1.8; font-size: 1.2rem; }
-        .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
+        .site-header {
+            position: sticky;
+            top: 0;
+            width: 100%;
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 4px solid var(--accent-color);
+            transition: all 0.3s ease;
+        }
+        .site-header.scrolled {
+            padding: 10px 40px;
+            background: #fff;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
@@ -44,7 +62,7 @@
     </style>
 </head>
 <body class="lang-nl">
-    <header class="header">
+    <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
@@ -92,8 +110,13 @@
                 nlBtn.classList.toggle('active', lang === 'nl');
                 enBtn.classList.toggle('active', lang === 'en');
             }
-            nlBtn.addEventListener('click', () => switchLanguage('nl'));
+           nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
+
+            const header = document.querySelector('.site-header');
+            document.addEventListener('scroll', () => {
+                header.classList.toggle('scrolled', window.pageYOffset > 0);
+            });
         });
     </script>
 </body>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -5,11 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Technische Gegevens - Mori</title>
     <style>
+        :root {
+            --accent-color: #2F4858;
+        }
         body, html { margin: 0; padding: 0; font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #F8F5F2; color: #333; scroll-behavior: smooth; }
         .lang-nl [lang="en"] { display: none; } .lang-en [lang="nl"] { display: none; }
         h1 { font-family: 'Times New Roman', serif; font-weight: normal; font-size: 2.5rem; text-align: center; margin-bottom: 2rem; color: #2F4858;}
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; }
-        .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
+        .site-header {
+            position: sticky;
+            top: 0;
+            width: 100%;
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 4px solid var(--accent-color);
+            transition: all 0.3s ease;
+        }
+        .site-header.scrolled {
+            padding: 10px 40px;
+            background: #fff;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
@@ -39,7 +57,7 @@
     </style>
 </head>
 <body class="lang-nl">
-    <header class="header">
+    <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
@@ -122,8 +140,13 @@
                 nlBtn.classList.toggle('active', lang === 'nl');
                 enBtn.classList.toggle('active', lang === 'en');
             }
-            nlBtn.addEventListener('click', () => switchLanguage('nl'));
+           nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
+
+            const header = document.querySelector('.site-header');
+            document.addEventListener('scroll', () => {
+                header.classList.toggle('scrolled', window.pageYOffset > 0);
+            });
         });
     </script>
 </body>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -5,13 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Algemene Voorwaarden - Mori</title>
     <style>
+        :root {
+            --accent-color: #2F4858;
+        }
         body, html { margin: 0; padding: 0; font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #F8F5F2; color: #333; scroll-behavior: smooth; }
         .lang-nl [lang="en"] { display: none; } .lang-en [lang="nl"] { display: none; }
         h1, h2, h3 { font-family: 'Times New Roman', serif; font-weight: normal; }
         h1 { font-size: 2.5rem; text-align: center; margin-bottom: 2rem; color: #2F4858;}
         h2 { font-size: 1.5rem; margin-top: 2rem; color: #2F4858;}
         .section { padding: 60px 20px; max-width: 800px; margin: 0 auto; line-height: 1.6; }
-        .header { padding: 20px 40px; display: flex; justify-content: space-between; align-items: center; background-color: #fff; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
+        .site-header {
+            position: sticky;
+            top: 0;
+            width: 100%;
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 4px solid var(--accent-color);
+            transition: all 0.3s ease;
+        }
+        .site-header.scrolled {
+            padding: 10px 40px;
+            background: #fff;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
         .header-logo { width: 150px; height: auto; }
         .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
         .lang-switcher img.active { border-color: #2F4858; }
@@ -39,7 +57,7 @@
     </style>
 </head>
 <body class="lang-nl">
-    <header class="header">
+    <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
             <img src="https://flagcdn.com/nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
@@ -127,8 +145,13 @@
                 nlBtn.classList.toggle('active', lang === 'nl');
                 enBtn.classList.toggle('active', lang === 'en');
             }
-            nlBtn.addEventListener('click', () => switchLanguage('nl'));
+           nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
+
+            const header = document.querySelector('.site-header');
+            document.addEventListener('scroll', () => {
+                header.classList.toggle('scrolled', window.pageYOffset > 0);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- make header sticky across pages with `site-header` class
- shrink header padding and add background on scroll
- add accent-colored bottom border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e616aa39c832b96b61cba15059f40