### PR TITLE
Adjust subpage header height and video behavior

### DIFF
--- a/instructies.html
+++ b/instructies.html
@@ -17,15 +17,16 @@
             position: sticky;
             top: 0;
             width: 100%;
-            padding: 20px 40px;
+            padding: 12px 40px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             border-bottom: 4px solid var(--accent-color);
             transition: all 0.3s ease;
+            z-index: 10;
         }
         .site-header.scrolled {
-            padding: 10px 40px;
+            padding: 6px 40px;
             background: #fff;
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
@@ -52,14 +53,19 @@
         .footer-links, .footer-contact { flex: 1; min-width: 200px; text-align: left; }
         .footer-links a { display: block; margin: 5px 0; }
         .footer p { font-size: 0.9rem; margin: 5px 0; }
-        .video-placeholder { width: 100%; height: 0; padding-bottom: 56.25%; background-color: #ccc; position: relative; border-radius: 8px; }
-        .video-placeholder::after { content: '►'; font-size: 5rem; color: #fff; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }
+        .instruction-video {
+            width: 100%;
+            height: auto;
+            display: block;
+            position: relative;
+            border-radius: 8px;
+        }
         .steps { margin-top: 40px; }
         .step { margin-bottom: 30px; }
         .step h3 { color: #2F4858; }
     </style>
 </head>
-<body class="lang-nl">
+<body class="lang-nl subpage">
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">
@@ -72,7 +78,7 @@
         <h1 lang="nl">Ophanginstructies</h1>
         <h1 lang="en">Hanging Instructions</h1>
         
-        <div class="video-placeholder"></div>
+        <video class="instruction-video" controls src="PXL_20250610_105508989.mp4"></video>
 
         <div class="steps">
             <div class="step" lang="nl">

--- a/over-ons.html
+++ b/over-ons.html
@@ -17,15 +17,16 @@
             position: sticky;
             top: 0;
             width: 100%;
-            padding: 20px 40px;
+            padding: 12px 40px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             border-bottom: 4px solid var(--accent-color);
             transition: all 0.3s ease;
+            z-index: 10;
         }
         .site-header.scrolled {
-            padding: 10px 40px;
+            padding: 6px 40px;
             background: #fff;
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
@@ -61,7 +62,7 @@
         .map-container iframe { width: 100%; height: 100%; border: 0; filter: grayscale(100%); }
     </style>
 </head>
-<body class="lang-nl">
+<body class="lang-nl subpage">
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -16,15 +16,16 @@
             position: sticky;
             top: 0;
             width: 100%;
-            padding: 20px 40px;
+            padding: 12px 40px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             border-bottom: 4px solid var(--accent-color);
             transition: all 0.3s ease;
+            z-index: 10;
         }
         .site-header.scrolled {
-            padding: 10px 40px;
+            padding: 6px 40px;
             background: #fff;
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
@@ -56,7 +57,7 @@
         .spec-table th { background-color: #EAE7E1; }
     </style>
 </head>
-<body class="lang-nl">
+<body class="lang-nl subpage">
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -18,15 +18,16 @@
             position: sticky;
             top: 0;
             width: 100%;
-            padding: 20px 40px;
+            padding: 12px 40px;
             display: flex;
             justify-content: space-between;
             align-items: center;
             border-bottom: 4px solid var(--accent-color);
             transition: all 0.3s ease;
+            z-index: 10;
         }
         .site-header.scrolled {
-            padding: 10px 40px;
+            padding: 6px 40px;
             background: #fff;
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
@@ -56,7 +57,7 @@
         .disclaimer { background-color: #EAE7E1; border-left: 4px solid #2F4858; padding: 15px; margin-bottom: 20px; font-style: italic;}
     </style>
 </head>
-<body class="lang-nl">
+<body class="lang-nl subpage">
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
         <div class="lang-switcher">


### PR DESCRIPTION
## Summary
- shrink header padding on subpages for less whitespace
- ensure header sits above content with `z-index`
- embed the instruction video and style it so it scrolls normally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e64ad71e0832baaab81b4236b02ef