### PR TITLE
Logo terug op indexpagina zonder header

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,9 @@
     </style>
 </head>
 <body class="lang-nl">
-    <a href="index.html" class="fixed-logo"><img src="logo-light.png" alt="Mori Logo" class="header-logo"></a>
+    <a href="index.html" class="fixed-logo" aria-label="Home">
+        <img src="logo-light.png" alt="Mori Logo" class="header-logo">
+    </a>
     <div class="lang-switcher fixed-switcher">
         <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
         <img src="flag-gb.svg" alt="English" id="lang-en-btn">

--- a/index.html
+++ b/index.html
@@ -87,6 +87,12 @@
             right: 40px;
             z-index: 11;
         }
+        .fixed-logo {
+            position: fixed;
+            top: 20px;
+            left: 40px;
+            z-index: 11;
+        }
 
         /* Hero Section */
         .hero {
@@ -352,6 +358,7 @@
     </style>
 </head>
 <body class="lang-nl">
+    <a href="index.html" class="fixed-logo"><img src="logo-light.png" alt="Mori Logo" class="header-logo"></a>
     <div class="lang-switcher fixed-switcher">
         <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
         <img src="flag-gb.svg" alt="English" id="lang-en-btn">


### PR DESCRIPTION
## Summary
- show the logo-light.png back on the index page without adding a header
- added `.fixed-logo` class to position the logo

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685e68b2a89c832b83adb1f4ff2416c9