### PR TITLE
Remove header on homepage and overlay logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,13 @@
             background: url('cb3aac09-9fd5-4681-8ea1-593e8e07a802.jpeg') no-repeat center center/cover;
             color: #fff;
         }
+        .hero-logo {
+            position: absolute;
+            top: 20px;
+            left: 40px;
+            width: 150px;
+            z-index: 2;
+        }
         .hero::after { content: ''; position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.4); z-index: 1; }
         .hero-content { position: relative; z-index: 2; }
         .hero h1 { margin: 0; }
@@ -352,14 +359,12 @@
     </style>
 </head>
 <body class="lang-nl">
-    <header class="site-header">
-        <a href="index.html"><img src="logo-light.png" alt="Mori Logo" class="header-logo"></a>
-    </header>
     <div class="lang-switcher fixed-switcher">
         <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
         <img src="flag-gb.svg" alt="English" id="lang-en-btn">
     </div>
     <section class="hero">
+        <img src="logo-light.png" alt="Mori Logo" class="hero-logo">
         <div class="hero-content">
             <h1 lang="nl">Licht dat leeft.</h1><h1 lang="en">Light That Lives.</h1>
             <p lang="nl">Handgemaakte, made-to-order verlichting die de essentie van het bos in je huis brengt.</p><p lang="en">Handcrafted, made-to-order lighting that brings the essence of the forest into your home.</p>
@@ -512,13 +517,6 @@
             }
             nlBtn.addEventListener('click', () => switchLanguage('nl'));
             enBtn.addEventListener('click', () => switchLanguage('en'));
-
-            const header = document.querySelector('.site-header');
-            if (header) {
-                document.addEventListener('scroll', () => {
-                    header.classList.toggle('scrolled', window.pageYOffset > 0);
-                });
-            }
 
             // Lightbox
             const lightbox = document.getElementById('delayed-lightbox');


### PR DESCRIPTION
## Summary
- remove the header element from `index.html`
- overlay `logo-light.png` directly on the hero section
- drop unused header scroll script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6e7ebc00832b9b3b2025943498e8