### PR TITLE
Update language switcher to text

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,14 +73,15 @@
         .header-logo { width: 150px; height: auto; }
 
         /* Language Switcher */
-        .lang-switcher img {
-            width: 30px;
+        .lang-switcher span {
             cursor: pointer;
             margin-left: 10px;
             border: 2px solid transparent;
             border-radius: 4px;
+            padding: 2px 6px;
+            color: #fff;
         }
-        .lang-switcher img.active { border-color: #fff; }
+        .lang-switcher span.active { border-color: #fff; }
         .fixed-switcher {
             position: fixed;
             top: 20px;
@@ -345,7 +346,7 @@
             .lamp-section { flex-direction: column; padding: 40px 15px; }
             .site-header { padding: 20px; }
             .header-logo { width: 120px; }
-            .lang-switcher img { width: 25px; }
+            .lang-switcher span { font-size: 0.9rem; }
         }
          @media (max-width: 500px) {
             .detail-gallery-grid, .wood-types-grid { grid-template-columns: repeat(1, 1fr); }
@@ -360,8 +361,8 @@
 </head>
 <body class="lang-nl">
     <div class="lang-switcher fixed-switcher">
-        <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
-        <img src="flag-gb.svg" alt="English" id="lang-en-btn">
+        <span id="lang-nl-btn" class="active">NL</span> |
+        <span id="lang-en-btn">ENG</span>
     </div>
     <section class="hero">
         <img src="logo-light.png" alt="Mori Logo" class="hero-logo">

--- a/instructies.html
+++ b/instructies.html
@@ -31,8 +31,8 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
-        .lang-switcher img.active { border-color: #fff; }
+        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span.active { border-color: #fff; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }
         .footer {
             background-color: #2F4858;
@@ -68,8 +68,8 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
-        <img src="flag-gb.svg" alt="English" id="lang-en-btn">
+        <span id="lang-nl-btn" class="active">NL</span> |
+        <span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/over-ons.html
+++ b/over-ons.html
@@ -31,8 +31,8 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
-        .lang-switcher img.active { border-color: #fff; }
+        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span.active { border-color: #fff; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }
         .footer {
             background-color: #2F4858;
@@ -65,8 +65,8 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
-        <img src="flag-gb.svg" alt="English" id="lang-en-btn">
+        <span id="lang-nl-btn" class="active">NL</span> |
+        <span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -30,8 +30,8 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
-        .lang-switcher img.active { border-color: #fff; }
+        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span.active { border-color: #fff; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }
         .footer {
             background-color: #2F4858;
@@ -60,8 +60,8 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
-        <img src="flag-gb.svg" alt="English" id="lang-en-btn">
+        <span id="lang-nl-btn" class="active">NL</span> |
+        <span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -32,8 +32,8 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher img { width: 30px; cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; }
-        .lang-switcher img.active { border-color: #fff; }
+        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span.active { border-color: #fff; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }
         .footer {
             background-color: #2F4858;
@@ -60,8 +60,8 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <img src="flag-nl.svg" alt="Nederlands" id="lang-nl-btn" class="active">
-        <img src="flag-gb.svg" alt="English" id="lang-en-btn">
+        <span id="lang-nl-btn" class="active">NL</span> |
+        <span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>


### PR DESCRIPTION
## Summary
- replace flag icons with text in language switcher

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685ee79ac57c832b813ff75f15a02aa3