### PR TITLE
Align language bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         /* Language Switcher */
         .lang-switcher span {
             cursor: pointer;
-            margin-left: 10px;
+            margin: 0 10px;
             border: 2px solid transparent;
             border-radius: 4px;
             padding: 2px 6px;

--- a/instructies.html
+++ b/instructies.html
@@ -31,7 +31,7 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span { cursor: pointer; margin: 0 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
         .lang-switcher span.active { border-color: #fff; }
         .lang-switcher .separator { color: #fff; margin: 0 5px; display: inline-block; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }

--- a/over-ons.html
+++ b/over-ons.html
@@ -31,7 +31,7 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span { cursor: pointer; margin: 0 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
         .lang-switcher span.active { border-color: #fff; }
         .lang-switcher .separator { color: #fff; margin: 0 5px; display: inline-block; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -30,7 +30,7 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span { cursor: pointer; margin: 0 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
         .lang-switcher span.active { border-color: #fff; }
         .lang-switcher .separator { color: #fff; margin: 0 5px; display: inline-block; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -32,7 +32,7 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.1);
         }
         .header-logo { width: 150px; height: auto; }
-        .lang-switcher span { cursor: pointer; margin-left: 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
+        .lang-switcher span { cursor: pointer; margin: 0 10px; border: 2px solid transparent; border-radius: 4px; padding: 2px 6px; color: #fff; }
         .lang-switcher span.active { border-color: #fff; }
         .lang-switcher .separator { color: #fff; margin: 0 5px; display: inline-block; }
         .fixed-switcher { position: fixed; top: 20px; right: 40px; z-index: 11; }


### PR DESCRIPTION
## Summary
- standardize spacing around language switcher so `NL | ENG` is centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ef4d7c65c832b9ced82d7bd19ecbb