### PR TITLE
Fix spacing around language switcher separator

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
 </head>
 <body class="lang-nl">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
     </div>
     <section class="hero">
         <img src="logo-light.png" alt="Mori Logo" class="hero-logo">

--- a/instructies.html
+++ b/instructies.html
@@ -73,7 +73,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/over-ons.html
+++ b/over-ons.html
@@ -70,7 +70,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -65,7 +65,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -65,7 +65,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>


### PR DESCRIPTION
## Summary
- show "NL | ENG" in the language switcher for all pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ef71fd450832b955704d6cfb8cb16