### PR TITLE
Fix about page layout

### DIFF
--- a/over-ons.html
+++ b/over-ons.html
@@ -103,13 +103,15 @@
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>
     </header>
 
-    <main class="section about-section">
-        <h1 lang="nl">Over ons</h1>
-        <h1 lang="en">About us</h1>
-        <p class="story-text" lang="nl">Mori is ontstaan uit een vriendschap tussen drie vrienden: Olle, de houtbewerker met een passie voor perfectie; John, die de lampen in beeld brengt; en Rik, de creative die ons verhaal vertelt. Gevestigd in een oude werkplaats in 's-Hertogenbosch, delen we een liefde voor natuurlijke materialen en tijdloos design. Samen creëren we meer dan alleen lampen; we maken rustpunten in een snelle wereld, met de hoop dat elk stuk een beetje van die rust bij jou thuis brengt.</p>
-        <p class="story-text" lang="en">Mori was born from a friendship between three friends: Olle, the woodworker with a passion for perfection; John, who captures our lamps on film; and Rik, the creative who tells our story. Based in an old workshop in 's-Hertogenbosch, we share a love for natural materials and timeless design. Together, we create more than just lamps; we create pockets of tranquility in a fast-paced world, hoping that each piece brings a little of that peace into your home.</p>
-        <p class="story-text" lang="nl">Bezoek onze werkplaats op de Poeldonkweg 5 in ’s-Hertogenbosch</p>
-        <p class="story-text" lang="en">Visit our workshop at Poeldonkweg 5 in ’s-Hertogenbosch</p>
+    <main class="about-section">
+        <div class="section">
+            <h1 lang="nl">Over ons</h1>
+            <h1 lang="en">About us</h1>
+            <p class="story-text" lang="nl">Mori is ontstaan uit een vriendschap tussen drie vrienden: Olle, de houtbewerker met een passie voor perfectie; John, die de lampen in beeld brengt; en Rik, de creative die ons verhaal vertelt. Gevestigd in een oude werkplaats in 's-Hertogenbosch, delen we een liefde voor natuurlijke materialen en tijdloos design. Samen creëren we meer dan alleen lampen; we maken rustpunten in een snelle wereld, met de hoop dat elk stuk een beetje van die rust bij jou thuis brengt.</p>
+            <p class="story-text" lang="en">Mori was born from a friendship between three friends: Olle, the woodworker with a passion for perfection; John, who captures our lamps on film; and Rik, the creative who tells our story. Based in an old workshop in 's-Hertogenbosch, we share a love for natural materials and timeless design. Together, we create more than just lamps; we create pockets of tranquility in a fast-paced world, hoping that each piece brings a little of that peace into your home.</p>
+            <p class="story-text" lang="nl">Bezoek onze werkplaats op de Poeldonkweg 5 in ’s-Hertogenbosch</p>
+            <p class="story-text" lang="en">Visit our workshop at Poeldonkweg 5 in ’s-Hertogenbosch</p>
+        </div>
     </main>
 
     <div class="map-container">


### PR DESCRIPTION
## Summary
- keep text centered within a fixed-width block on the about page

## Testing
- `xmllint --html --noout over-ons.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efe6b6360832b8a252f3a0ac90c9d