### PR TITLE
Update language switch spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
 </head>
 <body class="lang-nl">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
     </div>
     <section class="hero">
         <img src="logo-light.png" alt="Mori Logo" class="hero-logo">

--- a/instructies.html
+++ b/instructies.html
@@ -73,7 +73,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/over-ons.html
+++ b/over-ons.html
@@ -97,7 +97,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -65,7 +65,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -65,7 +65,7 @@
 </head>
 <body class="lang-nl subpage">
     <div class="lang-switcher fixed-switcher">
-        <span id="lang-nl-btn" class="active">NL</span><span class="separator"> | </span><span id="lang-en-btn">ENG</span>
+        <span id="lang-nl-btn" class="active">NL</span><span class="separator">|</span><span id="lang-en-btn">ENG</span>
     </div>
     <header class="site-header">
         <a href="index.html"><img src="logo-dark.png" alt="Mori Logo" class="header-logo"></a>


### PR DESCRIPTION
## Summary
- tighten spacing around the language switch

## Testing
- `grep -n "separator" index.html | head -n 2`
- `grep -n "separator" instructies.html | head -n 2`
- `grep -n "separator" over-ons.html | head -n 2`
- `grep -n "separator" tech-specs.html | head -n 2`
- `grep -n "separator" voorwaarden.html | head -n 2`


------
https://chatgpt.com/codex/tasks/task_e_685f0182d3b0832bab97249425852bab