### PR TITLE
Remove photos from close-up section

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,9 +405,6 @@
         <div class="detail-gallery-title">
             <h2 lang="nl">De lamp van dichtbij</h2><h2 lang="en">The lamp up close</h2>
         </div>
-        <div class="detail-gallery-grid">
-            <img src="PXL_20250610_092249397.PORTRAIT.jpg" alt="Detail van de houtconstructie van de Mori lamp"><img src="PXL_20250610_092311407.PORTRAIT.jpg" alt="Zijaanzicht van de Mori lamp in aanbouw"><img src="PXL_20250610_092324892.PORTRAIT.jpg" alt="Close-up van de hoek van de Mori lamp"><img src="PXL_20250610_092405563.PORTRAIT.jpg" alt="Detail van de houtnerf op de Mori lamp"><img src="PXL_20250610_092444477.PORTRAIT.jpg" alt="Houtnerf en constructie van de Mori lamp"><img src="PXL_20250610_092449174.PORTRAIT.jpg" alt="Constructie van de Mori lamp met gereedschap op de achtergrond"><img src="PXL_20250617_095719618.PORTRAIT.jpg" alt="Houten balken worden geklemd tijdens de productie"><img src="PXL_20250617_095806875.PORTRAIT.jpg" alt="Installatie van de elektronica in de Mori lamp">
-        </div>
         <div class="reserve-button-container">
             <a href="#register" class="reserve-link" lang="nl">Reserveer hier jouw Mori lamp</a><a href="#register" class="reserve-link" lang="en">Reserve your Mori lamp here</a>
         </div>


### PR DESCRIPTION
## Summary
- remove all photos from the "De lamp van dichtbij" section to simplify the page

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68aec2b71d74832b91b759087c76ef99