### PR TITLE
Add close-up gallery images to 'De lamp van dichtbij' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,6 +405,16 @@
         <div class="detail-gallery-title">
             <h2 lang="nl">De lamp van dichtbij</h2><h2 lang="en">The lamp up close</h2>
         </div>
+        <div class="detail-gallery-grid">
+            <img src="IMG_1372.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1335.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1357.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1352.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1360.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1363.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1368.JPG" alt="Detail view of the Mori lamp">
+            <img src="IMG_1371.JPG" alt="Detail view of the Mori lamp">
+        </div>
         <div class="reserve-button-container">
             <a href="#register" class="reserve-link" lang="nl">Reserveer hier jouw Mori lamp</a><a href="#register" class="reserve-link" lang="en">Reserve your Mori lamp here</a>
         </div>


### PR DESCRIPTION
## Summary
- add detail gallery grid for 'De lamp van dichtbij' with eight images

## Testing
- `npm test` (fails: package.json not found)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aecd19a780832bb3c2a05e23d37f13