### PR TITLE
Use workshop image for 'Handgemaakt in Nederland' background

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,11 +227,10 @@
             color: #333;
         }
 
-        /* Craftsmanship Video Section */
-        .craftsmanship-section { position: relative; padding: 80px 20px; text-align: center; overflow: hidden; color: #fff; }
-        #bg-video { position: absolute; top: 50%; left: 50%; min-width: 100%; min-height: 100%; width: auto; height: auto; z-index: 1; transform: translateX(-50%) translateY(-50%); }
-        .craftsmanship-section .overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.6); z-index: 2; }
-        .craftsmanship-content { position: relative; z-index: 3; max-width: 800px; margin: 0 auto; }
+        /* Craftsmanship Image Section */
+        .craftsmanship-section { position: relative; padding: 80px 20px; text-align: center; overflow: hidden; color: #fff; background: url('olle aan het werk - lamp.jpg') no-repeat center center/cover; }
+        .craftsmanship-section .overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.6); z-index: 1; }
+        .craftsmanship-content { position: relative; z-index: 2; max-width: 800px; margin: 0 auto; }
         .craftsmanship-content h2 { color: #fff; }
 
         /* Registration Section */
@@ -452,7 +451,6 @@
     </section>
     <section class="craftsmanship-section">
         <div class="overlay"></div>
-        <video autoplay loop muted playsinline id="bg-video"><source src="PXL_20250610_105508989.mp4" type="video/mp4"></video>
         <div class="craftsmanship-content">
             <h2 lang="nl">Handgemaakt in Nederland</h2><h2 lang="en">Handcrafted in the Netherlands</h2>
             <p lang="nl">Elke Mori lamp wordt met trots en precisie handgemaakt in onze werkplaats in 's-Hertogenbosch, Nederland. Van het zorgvuldig selecteren van het hout tot de uiteindelijke afwerking, elke stap is een belofte van kwaliteit en toewijding. Dit Nederlandse vakmanschap zorgt ervoor dat uw lamp niet zomaar een product is, maar een uniek en duurzaam designstuk met een eigen verhaal.</p><p lang="en">Every Mori lamp is proudly and precisely handcrafted in our workshop in 's-Hertogenbosch, the Netherlands. From carefully selecting the wood to the final finish, every step is a promise of quality and dedication. This Dutch craftsmanship ensures that your lamp is not just a product, but a unique and sustainable piece of design with its own story.</p>


### PR DESCRIPTION
## Summary
- Replace video background with a static workshop image for the "Handgemaakt in Nederland" section
- Clean up related CSS and markup to remove unused video element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed213eb74832b80f1559e6772c7c2