### PR TITLE
Make embedded Google Form responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,16 @@
             margin-top: -1rem;
             margin-bottom: 2rem;
         }
+        .form-container iframe {
+            width: 100%;
+            border: 0;
+            height: 2031px;
+        }
+        @media (max-width: 640px) {
+            .form-container iframe {
+                height: 2600px;
+            }
+        }
         .form-group { margin-bottom: 1.5rem; }
         .form-group label { display: block; margin-bottom: 0.5rem; color: #555; font-size: 0.9rem; font-weight: bold; }
         .form-group input, .form-group select { width: 100%; padding: 12px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; font-size: 1rem; }
@@ -470,7 +480,7 @@
             <h2 lang="nl">Reserveer jouw Mori</h2><h2 lang="en">Reserve your Mori</h2>
             <p class="visit-prompt" lang="nl">Wil je meer van de lamp zien? Kom langs in onze werkplaats of plan een video call.</p><p class="visit-prompt" lang="en">Want to see more of the lamp? Visit our workshop or schedule a video call.</p>
             <p lang="nl">Word een van de weinigen die een Mori-lamp bezit uit onze eerste gelimiteerde productierun. Vul onderstaand formulier in om je voorkeuren te selecteren en je interesse te registreren. We nemen contact met je op om je bestelling af te ronden.</p><p lang="en">Become one of the few to own a Mori lamp from our first limited production run. Complete the form below to select your preferences and register your interest. We will contact you to finalize your order.</p>
-            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmFCxtVkPsMrlkViqmIlmNcr3-hBzJgn8ri8w_UERJCdD7hA/viewform?embedded=true" width="640" height="2031" frameborder="0" marginheight="0" marginwidth="0">Laden…</iframe>
+            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmFCxtVkPsMrlkViqmIlmNcr3-hBzJgn8ri8w_UERJCdD7hA/viewform?embedded=true" frameborder="0" marginheight="0" marginwidth="0">Laden…</iframe>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- adjust styles to make embedded Google Form fill container width and adapt height for small screens
- drop fixed width/height attributes from iframe embedding the form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2889ee68832ba5b5cdb9ed77681c