### PR TITLE
Center wood type images

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,10 +210,11 @@
         /* Wood types Section */
         .wood-types-grid {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
+            grid-template-columns: repeat(2, 1fr);
             gap: 20px;
             text-align: center;
-            margin-top: 2rem;
+            margin: 2rem auto 0 auto;
+            max-width: 600px;
         }
         .wood-type-item img {
             width: 100%;


### PR DESCRIPTION
## Summary
- Center wood type images "Eiken" and "Noten" by limiting grid width and centering the grid in the wood types section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b08a103a9c832b8d4f67879b7f8202