### PR TITLE
Make order popup form responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,11 +379,18 @@
         }
         #popupContent {
             background-color: #fff;
-            margin: 10% auto;
+            margin: 5vh auto;
             padding: 20px;
-            width: 720px;
-            max-width: 90%;
+            width: 90%;
+            max-width: 720px;
+            height: 90vh;
+            box-sizing: border-box;
             position: relative;
+        }
+        #popupContent iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
         }
         #closePopup {
             position: absolute;
@@ -393,12 +400,6 @@
             background: none;
             font-size: 24px;
             cursor: pointer;
-        }
-        @media (max-width: 768px) {
-            #popupContent {
-                margin: 20% auto;
-                width: 90%;
-            }
         }
     </style>
 </head>
@@ -546,7 +547,7 @@
     <div id="popup">
         <div id="popupContent">
             <button id="closePopup">&times;</button>
-            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmFCxtVkPsMrlkViqmIlmNcr3-hBzJgn8ri8w_UERJCdD7hA/viewform?embedded=true" width="700" height="520" frameborder="0" marginheight="0" marginwidth="0">Laden…</iframe>
+            <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmFCxtVkPsMrlkViqmIlmNcr3-hBzJgn8ri8w_UERJCdD7hA/viewform?embedded=true" width="100%" height="100%" frameborder="0" marginheight="0" marginwidth="0">Laden…</iframe>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Rework popup order form styling to use viewport-based sizing and flexible iframe.
- Ensure embedded Google Form scales to mobile screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b69fe210a0832b9a69fada7576be9c