### PR TITLE
Shrink Keuken Nordic image by 30%

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
         </div>
     </section>
     <section id="lamp" class="section lamp-section">
-        <div class="lamp-image"><img src="Keuken Nordic 2.jpg" alt="Mori lamp in a Nordic kitchen"></div>
+        <div class="lamp-image"><img src="Keuken Nordic 2.jpg" alt="Mori lamp in a Nordic kitchen" style="width:70%;height:auto;"></div>
         <div class="lamp-description">
             <h3 lang="nl">Handgemaakte excellentie</h3><h3 lang="en">Handmade excellence</h3>
             <p lang="nl">Elke Mori-lamp wordt met de hand gemaakt, stuk voor stuk. Niet vanuit massa, maar vanuit aandacht. Elke lamp vertelt het verhaal van de boom waar het hout vandaan komt en de handen die het hebben bewerkt.</p><p lang="en">Every Mori lamp is crafted by hand, piece by piece. Not from mass production, but from focused attention. Each lamp tells the story of the wood it comes from and the hands that shaped it.</p>


### PR DESCRIPTION
## Summary
- display "Keuken Nordic 2.jpg" at 70% width to make the lamp photo 30% smaller.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b69fa85e98832baeeca248bd232317