### PR TITLE
Improve mobile alignment of language switcher

### DIFF
--- a/bestellen.html
+++ b/bestellen.html
@@ -39,6 +39,9 @@
         .form-container p { text-align: center; margin-bottom: 2rem; }
         .form-container .visit-prompt { font-style: italic; margin-top: -1rem; margin-bottom: 2rem; }
         /* Removed iframe-specific styles; Fillout embed handles its own sizing */
+        @media (max-width: 768px) {
+            .fixed-switcher { right: 20px; }
+        }
     </style>
 </head>
 <body class="lang-nl subpage">

--- a/index.html
+++ b/index.html
@@ -353,6 +353,7 @@
             .site-header { padding: 20px; }
             .header-logo { width: 120px; }
             .lang-switcher span { font-size: 0.9rem; }
+            .fixed-switcher { right: 20px; }
             .footer-links { margin-left: 0; }
         }
         @media (max-width: 500px) {

--- a/instructies.html
+++ b/instructies.html
@@ -68,6 +68,7 @@
         .step h3 { color: #2F4858; }
         @media (max-width: 768px) {
             .footer-links { margin-left: 0; }
+            .fixed-switcher { right: 20px; }
         }
     </style>
 </head>

--- a/over-ons.html
+++ b/over-ons.html
@@ -92,6 +92,7 @@
         .map-container iframe { width: 100%; height: 100%; border: 0; filter: grayscale(100%); }
         @media (max-width: 768px) {
             .footer-links { margin-left: 0; }
+            .fixed-switcher { right: 20px; }
         }
     </style>
 </head>

--- a/tech-specs.html
+++ b/tech-specs.html
@@ -60,6 +60,7 @@
         .spec-table th { background-color: #EAE7E1; }
         @media (max-width: 768px) {
             .footer-links { margin-left: 0; }
+            .fixed-switcher { right: 20px; }
         }
     </style>
 </head>

--- a/voorwaarden.html
+++ b/voorwaarden.html
@@ -60,6 +60,7 @@
         .disclaimer { background-color: #EAE7E1; border-left: 4px solid #2F4858; padding: 15px; margin-bottom: 20px; font-style: italic;}
         @media (max-width: 768px) {
             .footer-links { margin-left: 0; }
+            .fixed-switcher { right: 20px; }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- reduce the right offset of the language switcher on mobile breakpoints so it aligns with the page edge
- apply the same responsive adjustment across the homepage and all subpages that use the floating language toggle

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3c4648694832b8e7071d70802f81b